### PR TITLE
Must use lowercase for the SQL Server servername. AB#4314

### DIFF
--- a/PartsUnlimited-aspnet45/env/PartsUnlimitedEnv/Templates/FullEnvironmentSetupMerged.json
+++ b/PartsUnlimited-aspnet45/env/PartsUnlimitedEnv/Templates/FullEnvironmentSetupMerged.json
@@ -54,8 +54,8 @@
   },
   "variables": {
     "PartsUnlimitedServerName": "[toLower(parameters('PUL_ServerName'))]",
-    "PartsUnlimitedServerNameDev": "[concat(variables('PartsUnlimitedServerName'), 'Dev')]",
-    "PartsUnlimitedServerNameQA": "[concat(variables('PartsUnlimitedServerName'), 'QA')]"
+    "PartsUnlimitedServerNameDev": "[concat(variables('PartsUnlimitedServerName'), 'dev')]",
+    "PartsUnlimitedServerNameQA": "[concat(variables('PartsUnlimitedServerName'), 'qa')]"
   },
   "resources": [
     {


### PR DESCRIPTION
SQL Server servernames must be all lowercase. 